### PR TITLE
feature: Add headerKey config for custom header config

### DIFF
--- a/src/Schemes/Api.js
+++ b/src/Schemes/Api.js
@@ -20,10 +20,16 @@ const CE = require('../Exceptions')
  * to authenticate a user.
  *
  * The tokens for a give user are stored inside the database and user sends
- * a token inside the `Authorization` header as following.
+ * a token inside the `Authorization` header or custom header if present from config as following.
  *
  * ```
  * Authorization=Bearer TOKEN
+ * ```
+ *
+ * With custom header config:
+ *
+ * ```
+ * CustomHeader=Bearer TOKEN
  * ```
  *
  * ### Note
@@ -238,7 +244,7 @@ class ApiScheme extends BaseTokenScheme {
       const { token } = await this.generate(tokenOrUser)
       tokenOrUser = token
     }
-    headerFn('authorization', `Bearer ${tokenOrUser}`)
+    headerFn(this.headerKey, `Bearer ${tokenOrUser}`)
   }
 }
 

--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -63,6 +63,17 @@ class BaseScheme {
   }
 
   /**
+   * The headerKey used to get the token. Reads the `headerKey` from the config object
+   *
+   * @attribute headerKey
+   * @readonly
+   * @type {String}
+   */
+  get headerKey () {
+    return this._config.headerKey || 'authorization'
+  }
+
+  /**
    * The primary key to be used to fetch the unique identifier value
    * for the current user.
    *
@@ -237,7 +248,7 @@ class BaseScheme {
     /**
      * Parse the auth header and fetch token from it
      */
-    let token = request.header('authorization')
+    let token = request.header(this.headerKey)
     if (token) {
       token = token.split(' ')
       return (token.length === 2 && authTypes.indexOf(token[0].toLowerCase()) > -1) ? token[1] : null

--- a/src/Schemes/BasicAuth.js
+++ b/src/Schemes/BasicAuth.js
@@ -118,7 +118,7 @@ class BasicAuthScheme extends BaseScheme {
    * @return {void}
    */
   async clientLogin (headerFn, sessionFn, username, password) {
-    headerFn('authorization', `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`)
+    headerFn(this.headerKey, `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`)
   }
 }
 

--- a/src/Schemes/Jwt.js
+++ b/src/Schemes/Jwt.js
@@ -477,7 +477,7 @@ class JwtScheme extends BaseTokenScheme {
    */
   async clientLogin (headerFn, sessionFn, user) {
     const { token } = await this.generate(user)
-    headerFn('authorization', `Bearer ${token}`)
+    headerFn(this.headerKey, `Bearer ${token}`)
   }
 }
 

--- a/test/functional/setup/index.js
+++ b/test/functional/setup/index.js
@@ -72,7 +72,8 @@ module.exports = async () => {
         password: 'password',
         model: 'App/Models/User',
         serializer: 'lucid',
-        scheme: 'basic'
+        scheme: 'basic',
+        headerKey: 'basic'
       },
       jwt: {
         model: 'App/Models/User',
@@ -82,14 +83,16 @@ module.exports = async () => {
         password: 'password',
         options: {
           secret: 'SECRET'
-        }
+        },
+        headerKey: 'jwt'
       },
       api: {
         model: 'App/Models/User',
         scheme: 'api',
         serializer: 'lucid',
         uid: 'email',
-        password: 'password'
+        password: 'password',
+        headerKey: 'api'
       }
     })
 

--- a/test/functional/vow-bindings.spec.js
+++ b/test/functional/vow-bindings.spec.js
@@ -67,8 +67,10 @@ test.group('Vow Request', (group) => {
     assert.plan(2)
 
     const request = new Request()
+    const Config = ioc.use('Adonis/Src/Config')
+
     request.header = function (key, value) {
-      assert.equal(key, 'authorization')
+      assert.equal(key, Config.get('auth.basic.headerKey'))
       assert.equal(value, `Basic ${Buffer.from('foo:bar').toString('base64')}`)
     }
     request.session = function () {}
@@ -81,8 +83,9 @@ test.group('Vow Request', (group) => {
     assert.plan(2)
 
     const request = new Request()
+    const Config = ioc.use('Adonis/Src/Config')
     request.header = function (key, value) {
-      assert.equal(key, 'authorization')
+      assert.equal(key, Config.get('auth.jwt.headerKey'))
       assert.include(value, 'Bearer')
     }
     request.session = function () {}

--- a/test/unit/api-scheme.spec.js
+++ b/test/unit/api-scheme.spec.js
@@ -466,7 +466,8 @@ test.group('Schemes - Api', (group) => {
     const config = {
       model: User,
       uid: 'email',
-      password: 'password'
+      password: 'password',
+      headerKey: 'api'
     }
 
     const database = new DatabaseSerializer(ioc.use('Hash'))
@@ -476,7 +477,7 @@ test.group('Schemes - Api', (group) => {
     api.setOptions(config, database)
 
     const headerFn = function (key, value) {
-      assert.equal(key, 'authorization')
+      assert.equal(key, config.headerKey)
       assert.include(value, 'Bearer')
     }
 

--- a/test/unit/basicauth-scheme.spec.js
+++ b/test/unit/basicauth-scheme.spec.js
@@ -257,7 +257,8 @@ test.group('Schemes - BasicAuth', (group) => {
     const config = {
       model: User,
       uid: 'email',
-      password: 'password'
+      password: 'password',
+      headerKey: 'basic'
     }
 
     const lucid = new LucidSerializer(ioc.use('Hash'))
@@ -267,7 +268,7 @@ test.group('Schemes - BasicAuth', (group) => {
     basic.setOptions(config, lucid)
 
     const headerFn = function (key, value) {
-      assert.equal(key, 'authorization')
+      assert.equal(key, config.headerKey)
       assert.equal(value, `Basic ${Buffer.from('foo:secret').toString('base64')}`)
     }
 

--- a/test/unit/jwt-scheme.spec.js
+++ b/test/unit/jwt-scheme.spec.js
@@ -275,6 +275,7 @@ test.group('Schemes - Jwt', (group) => {
       model: User,
       uid: 'email',
       password: 'password',
+      headerKey: 'jwt',
       options: {
         secret: SECRET
       }
@@ -291,7 +292,7 @@ test.group('Schemes - Jwt', (group) => {
     jwt.setCtx({
       request: {
         header (key) {
-          return `Bearer ${token}`
+          return (key === config.headerKey) ? `Bearer ${token}` : false
         }
       }
     })
@@ -924,6 +925,7 @@ test.group('Schemes - Jwt', (group) => {
       uid: 'email',
       foreignKey: 'user_id',
       password: 'password',
+      headerKey: 'jwt',
       options: {
         secret: SECRET
       }
@@ -936,7 +938,7 @@ test.group('Schemes - Jwt', (group) => {
     jwt.setOptions(config, database)
 
     const headerFn = function (key, value) {
-      assert.equal(key, 'authorization')
+      assert.equal(key, config.headerKey)
       assert.include(value, 'Bearer')
     }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

The idea is to add a custom `headerKey` to allow changing default header key used to get the token from `basic, jwt, api` scheme

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-auth/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

Commit for the documentation: https://github.com/cmty/docs/commit/347f2bd0411a37e37fbd6dbf2bcbd943c96411aa
