### PR TITLE
feat: option to specify user's table identifier column

### DIFF
--- a/adonis-typings/auth.ts
+++ b/adonis-typings/auth.ts
@@ -161,6 +161,7 @@ declare module '@ioc:Adonis/Addons/Auth' {
 	export type DatabaseTokenProviderConfig = {
 		driver: 'database'
 		table: string
+		foreignKey?: string
 		connection?: string
 	}
 

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 3rd 2020, 4:00:19 pm
+                            October 6th 2020, 12:09:31 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 6th 2020, 12:09:31 pm
+                            October 6th 2020, 12:09:46 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            September 19th 2020, 2:04:08 pm
+                            October 3rd 2020, 4:00:19 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/TokenProviders/Database/index.ts
+++ b/src/TokenProviders/Database/index.ts
@@ -34,6 +34,13 @@ export class TokenDatabaseProvider implements TokenProviderContract {
 	}
 
 	/**
+	 * Returns the User's identifier column
+	 */
+	private getForeignKey() {
+		return this.config.foreignKey ?? 'user_id'
+	}
+
+	/**
 	 * Returns the builder query for a given token + type
 	 */
 	private getLookupQuery(tokenId: string) {
@@ -62,7 +69,14 @@ export class TokenDatabaseProvider implements TokenProviderContract {
 			return null
 		}
 
-		const { name, user_id: userId, token: value, expires_at: expiresAt, type, ...meta } = tokenRow
+		const {
+			name,
+			[this.getForeignKey()]: userId,
+			token: value,
+			expires_at: expiresAt,
+			type,
+			...meta
+		} = tokenRow
 		let normalizedExpiryDate: undefined | DateTime
 
 		/**
@@ -102,7 +116,7 @@ export class TokenDatabaseProvider implements TokenProviderContract {
 		 * Payload to save to the database
 		 */
 		const payload = {
-			user_id: token.userId,
+			[this.getForeignKey()]: token.userId,
 			name: token.name,
 			token: token.tokenHash,
 			type: token.type,

--- a/src/TokenProviders/Database/index.ts
+++ b/src/TokenProviders/Database/index.ts
@@ -34,11 +34,9 @@ export class TokenDatabaseProvider implements TokenProviderContract {
 	}
 
 	/**
-	 * Returns the User's identifier column
+	 * The foreign key column
 	 */
-	private getForeignKey() {
-		return this.config.foreignKey ?? 'user_id'
-	}
+	private foreignKey = this.config.foreignKey || 'user_id'
 
 	/**
 	 * Returns the builder query for a given token + type
@@ -71,7 +69,7 @@ export class TokenDatabaseProvider implements TokenProviderContract {
 
 		const {
 			name,
-			[this.getForeignKey()]: userId,
+			[this.foreignKey]: userId,
 			token: value,
 			expires_at: expiresAt,
 			type,
@@ -116,7 +114,7 @@ export class TokenDatabaseProvider implements TokenProviderContract {
 		 * Payload to save to the database
 		 */
 		const payload = {
-			[this.getForeignKey()]: token.userId,
+			[this.foreignKey]: token.userId,
 			name: token.name,
 			token: token.tokenHash,
 			type: token.type,

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -338,4 +338,77 @@ test.group('Auth', (group) => {
 		assert.instanceOf(auth.provider, LucidProvider)
 		assert.instanceOf(auth.tokenProvider, TokenDatabaseProvider)
 	})
+
+	test('return user_id when foreignKey is missing', (assert) => {
+		const User = getUserModel(BaseModel)
+
+		const manager = new AuthManager(container, {
+			guard: 'api',
+			list: {
+				api: {
+					driver: 'oat',
+					tokenProvider: {
+						driver: 'database',
+						table: 'api_tokens',
+					},
+					provider: getLucidProviderConfig({ model: User }),
+				},
+				basic: {
+					driver: 'basic',
+					provider: getLucidProviderConfig({ model: User }),
+				},
+				session: {
+					driver: 'session',
+					provider: getLucidProviderConfig({ model: User }),
+				},
+				sessionDb: {
+					driver: 'session',
+					provider: getDatabaseProviderConfig(),
+				},
+			},
+		})
+
+		const ctx = getCtx()
+		const auth = manager.getAuthForRequest(ctx).use('api')
+
+		assert.instanceOf(auth.tokenProvider, TokenDatabaseProvider)
+		assert.equal(auth.tokenProvider.foreignKey, 'user_id')
+	})
+
+	test('return the foreignKey when not missing', (assert) => {
+		const User = getUserModel(BaseModel)
+
+		const manager = new AuthManager(container, {
+			guard: 'api',
+			list: {
+				api: {
+					driver: 'oat',
+					tokenProvider: {
+						driver: 'database',
+						table: 'api_tokens',
+						foreignKey: 'account_id',
+					},
+					provider: getLucidProviderConfig({ model: User }),
+				},
+				basic: {
+					driver: 'basic',
+					provider: getLucidProviderConfig({ model: User }),
+				},
+				session: {
+					driver: 'session',
+					provider: getLucidProviderConfig({ model: User }),
+				},
+				sessionDb: {
+					driver: 'session',
+					provider: getDatabaseProviderConfig(),
+				},
+			},
+		})
+
+		const ctx = getCtx()
+		const auth = manager.getAuthForRequest(ctx).use('api')
+
+		assert.instanceOf(auth.tokenProvider, TokenDatabaseProvider)
+		assert.equal(auth.tokenProvider.foreignKey, 'account_id')
+	})
 })


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I'm using Adonis in one of my projects and due to internal nomenclature conflicts the `users` table actually mean a totally different thing from the original `users` table.

So, I renamed the `Users` model to `Account` and updated the config, everything work out perfectlly, but since I'm using the OAT guard, I have this in my `api_tokens` migration:

```ts
      table
        .integer('user_id')
        .unsigned()
        .references('id')
        .inTable('users')
        .onDelete('CASCADE')
```

I updated to this:

```ts
      table
        .integer('acccount_id')
        .unsigned()
        .references('id')
        .inTable('accounts')
        .onDelete('CASCADE')
```

But since the `user_id` is hardcoded inside the package, this throws an error:

```
insert into "api_tokens" ("created_at", "expires_at", "name", "token", "type", "user_id") values ($1, $2, $3, $4, $5, $6) returning "id" - column "user_id" of relation "api_tokens" does not exist
```

Obivouslly I could do:

```ts
      table
        .integer('user_id')
        .unsigned()
        .references('id')
        .inTable('accounts')
        .onDelete('CASCADE')
```

But I think this is missleading, as `User` exists and is a completly different entity, in my case.

I do understand that this is probably not a very common issue, so I tried to make this a non-breaking-change.

Currently the `DatabaseTokenProviderConfig` looks like this:

```ts
// adonis-typings/auth.ts

	export type DatabaseTokenProviderConfig = {
		driver: 'database'
		table: string
		connection?: string
	}
```

I changed to this:

```ts
// adonis-typings/auth.ts
	export type DatabaseTokenProviderConfig = {
		driver: 'database'
		table: string
		foreignKey?: string
		connection?: string
	}
```

Notice `foreignKey` is optional. As most of the times the `foreignKey` will be `user_id`, I think that maybe we could automatically infer the `foreignKey` as being `user_id`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

As I said I don't think this is a relevant change at all, but since is possible to change the default "users" table maybe would also be usefull to have the ability to change the foreign key.