### PR TITLE
fix: correct type returned by GetProviderRealUser

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,7 @@
 {
   "extends": [
     "plugin:adonis/typescriptPackage",
-    "prettier",
-    "prettier/@typescript-eslint"
+    "prettier"
   ],
   "plugins": [
     "prettier"

--- a/adonis-typings/auth.ts
+++ b/adonis-typings/auth.ts
@@ -28,10 +28,15 @@ declare module '@ioc:Adonis/Addons/Auth' {
   type UnWrapProviderUser<T> = T extends ProviderUserContract<any> ? Exclude<T['user'], null> : T
 
   /**
+   * Unwraps awaited type from Promise
+   */
+  type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T
+
+  /**
    * Returns the real user from the provider user
    */
   export type GetProviderRealUser<Provider extends keyof ProvidersList> = UnWrapProviderUser<
-    ReturnType<ProvidersList[Provider]['implementation']['getUserFor']>
+    Awaited<ReturnType<ProvidersList[Provider]['implementation']['getUserFor']>>
   >
 
   /*

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
     "cz-conventional-changelog": "^3.3.0",
     "del-cli": "^3.0.1",
     "eslint": "^7.20.0",
-    "eslint-config-prettier": "^7.2.0",
+    "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-adonis": "^1.2.1",
     "eslint-plugin-prettier": "^3.3.1",
     "github-label-sync": "^2.0.0",
-    "husky": "^5.0.9",
+    "husky": "^5.1.0",
     "japa": "^3.1.1",
     "mrm": "^2.5.19",
     "np": "^7.4.0",
@@ -102,7 +102,7 @@
     "anyBranch": false
   },
   "dependencies": {
-    "@poppinss/hooks": "^2.0.0",
+    "@poppinss/hooks": "^3.0.0",
     "@poppinss/utils": "^3.0.3",
     "luxon": "^1.26.0"
   },


### PR DESCRIPTION
Without this change, `ctx.auth.user` returns a Promise,
because that's the return type of `getUserFor`.
