### PR TITLE
fix: template should use correct table name for `user-provider-database.txt`

### DIFF
--- a/templates/config/partials/user-provider-database.txt
+++ b/templates/config/partials/user-provider-database.txt
@@ -40,4 +40,4 @@
       | field and `remember_me_token` column.
       |
       */
-      usersTable: {{ tableName }},
+      usersTable: {{ usersTableName }},


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Current template of config in partial `user-provider-database.txt` uses inappropriate table name for `usersTable` var (after install this var just empty string):
![image](https://user-images.githubusercontent.com/5501615/109162695-8de8c800-7789-11eb-9547-d0a28eba2c10.png)

Current PR fixes this by using `usersTableName` template var's value, which fulfilled during installation steps of `@adonisjs/auth`

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes