### PR TITLE
fix: `api_tokens` template should use `usersTableName` table

### DIFF
--- a/templates/migrations/api_tokens.txt
+++ b/templates/migrations/api_tokens.txt
@@ -6,7 +6,7 @@ export default class {{ tokensSchemaName }} extends BaseSchema {
   public async up () {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').primary()
-      table.integer('user_id').unsigned().references('id').inTable('users').onDelete('CASCADE')
+      table.integer('user_id').unsigned().references('id').inTable('{{ usersTableName }}').onDelete('CASCADE')
       table.string('name').notNullable()
       table.string('type').notNullable()
       table.string('token', 64).notNullable().unique()


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Current template `api_tokens` of migration ignores users table name configured during installation steps of `@adonisjs/auth`:
![image](https://user-images.githubusercontent.com/5501615/110043922-52399980-7d59-11eb-8b9c-c25fe1a7cbf7.png)

This PR fixes it, so template uses  `usersTableName` for migration.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes