### PR TITLE
fix: make peerDep @adonisjs/lucid as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,9 @@
     "@adonisjs/session": "^6.0.0"
   },
   "peerDependenciesMeta": {
+    "@adonisjs/lucid": {
+      "optional": true
+    },
     "@adonisjs/session": {
       "optional": true
     },


### PR DESCRIPTION
## Proposed changes

Make @adonisjs/lucid peer dependency as optional.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works. (N/A ?)

## Further comments

Without the change, installing `@adonisjs/auth` cause an error if `@adonisjs/lucid` is not installed.
```
npm ERR! code ERESOLVE
npm ERR! Found: @adonisjs/auth@6.0.1
npm ERR! node_modules/@adonisjs/auth
npm ERR!   @adonisjs/auth@"^7.0.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! @adonisjs/auth@"^7.0.0" from the root project
npm ERR!
npm ERR!   peer @adonisjs/lucid@"^12.0.0" from @adonisjs/auth@7.0.0
npm ERR!   node_modules/@adonisjs/auth
npm ERR!     @adonisjs/auth@"^7.0.0" from the root project
```
