### PR TITLE
Minor typo

### DIFF
--- a/templates/migrations/api_tokens.txt
+++ b/templates/migrations/api_tokens.txt
@@ -12,7 +12,7 @@ export default class extends BaseSchema {
       table.string('token', 64).notNullable().unique()
 
       /**
-       * Uses timestampz for PostgreSQL and DATETIME2 for MSSQL
+       * Uses timestamptz for PostgreSQL and DATETIME2 for MSSQL
        */
       table.timestamp('expires_at', { useTz: true }).nullable()
       table.timestamp('created_at', { useTz: true }).notNullable()

--- a/templates/migrations/auth.txt
+++ b/templates/migrations/auth.txt
@@ -11,7 +11,7 @@ export default class extends BaseSchema {
       table.string('remember_me_token').nullable()
 
       /**
-       * Uses timestampz for PostgreSQL and DATETIME2 for MSSQL
+       * Uses timestamptz for PostgreSQL and DATETIME2 for MSSQL
        */
       table.timestamp('created_at', { useTz: true }).notNullable()
       table.timestamp('updated_at', { useTz: true }).notNullable()


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Minor typo fixed: `timestampz` -> `timestamptz`.