### PR TITLE
Add custom token providers

### DIFF
--- a/adonis-typings/auth.ts
+++ b/adonis-typings/auth.ts
@@ -819,6 +819,14 @@ declare module '@ioc:Adonis/Addons/Auth' {
   ) => UserProviderContract<any>
 
   /**
+   * Shape of the callback accepted to add new token providers
+   */
+  export type ExtendTokenProviderCallback = (
+    auth: AuthManagerContract,
+    config: any
+  ) => TokenProviderContract
+
+  /**
    * Shape of the callback accepted to add new guards
    */
   export type ExtendGuardCallback = (
@@ -879,6 +887,7 @@ declare module '@ioc:Adonis/Addons/Auth' {
      * Extend by adding custom providers, guards and client
      */
     extend(type: 'provider', provider: string, callback: ExtendProviderCallback): void
+    extend(type: 'token', provider: string, callback: ExtendTokenProviderCallback): void
     extend(type: 'guard', guard: string, callback: ExtendGuardCallback): void
     extend(type: 'client', guard: string, callback: ExtendClientCallback): void
   }

--- a/standalone.ts
+++ b/standalone.ts
@@ -8,3 +8,4 @@
  */
 
 export { AuthenticationException } from './src/Exceptions/AuthenticationException'
+export { ProviderToken } from './src/Tokens/ProviderToken'


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I'd like to use API tokens with another database (mongodb) but creating a custom token provider is not possible at the time (and it's the aim of this Pull request).

I used the same code as for the existing custom providers and guards.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
_(There aren't any tests for the existing custom providers/guards)_
- [ ] I have added necessary documentation (if appropriate)
_Maybe, I should add this to the documentation like the existing ones. Tell me and I'll open a PR if needed !_

## Further comments

:warning: There's a small issue, I don't know how to update type declaration for configuration (to hide the warning `Type '"custom_provider"' is not assignable to type '"database" | "redis"'`)
