### PR TITLE
Let config set httpOnly on Remember Me Token

### DIFF
--- a/src/Guards/Session/index.ts
+++ b/src/Guards/Session/index.ts
@@ -95,7 +95,6 @@ export class SessionGuard extends BaseGuard<any> implements SessionGuardContract
 
     this.ctx.response.encryptedCookie(this.rememberMeKeyName, value, {
       maxAge: this.rememberMeTokenExpiry,
-      httpOnly: true,
     })
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I ran into an issue where I am using htmx's `hx-boost="true"` for SPA like abilities in my app and all of the sudden I kept getting logged out even after setting `Remember Me` on my auth session.

I dug in and learned that the remember me token cookie is not respecting `config/app.ts#cookie.httpOnly` option and overrides it breaking remember me abilities even though session cookies are respecting that configuration.

This PR removes that and defaults to the settings in your config for cookies so that way all cookies behave how you intend them to based on that configuration.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
