### PR TITLE
'guard' is never reassigned. Use 'const' instead.

### DIFF
--- a/templates/middleware/Auth.txt
+++ b/templates/middleware/Auth.txt
@@ -32,7 +32,7 @@ export default class AuthMiddleware {
      */
     let guardLastAttempted: string | undefined
 
-    for (let guard of guards) {
+    for (const guard of guards) {
       guardLastAttempted = guard
 
       if (await auth.use(guard).check()) {


### PR DESCRIPTION


<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This pull request addresses the prefer-const issue identified in our codebase. The change involves modifying the guard variable declaration from let to const in the authentication loop, as this variable is never reassigned. This change aligns with the global standard "prefer-const" of using const for variables that will not be mutated later.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/auth/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

The prefer-const rule is a widely accepted best practice in JavaScript and TypeScript development. It helps to prevent unintentional mutation of variables and makes the code easier to reason about. By making this change, we ensure that our code adheres to this best practice, making it more robust and maintainable.
