### PR TITLE
fix(mixins): receive a function instead of the hash module directly

### DIFF
--- a/src/mixins/with_auth_finder.ts
+++ b/src/mixins/with_auth_finder.ts
@@ -25,7 +25,7 @@ import { E_INVALID_CREDENTIALS } from '../errors.js'
  *   timing attacks.
  */
 export function withAuthFinder(
-  hash: Hash,
+  hash: () => Hash,
   options: {
     uids: string[]
     passwordColumnName: string
@@ -43,7 +43,7 @@ export function withAuthFinder(
         user: InstanceType<T>
       ) {
         if (user.$dirty[options.passwordColumnName]) {
-          ;(user as any)[options.passwordColumnName] = await hash.make(
+          ;(user as any)[options.passwordColumnName] = await hash().make(
             (user as any)[options.passwordColumnName]
           )
         }
@@ -82,7 +82,7 @@ export function withAuthFinder(
 
         const user = await this.findForAuth(options.uids, uid)
         if (!user) {
-          await hash.make(password)
+          await hash().make(password)
           throw new E_INVALID_CREDENTIALS('Invalid user credentials')
         }
 
@@ -93,7 +93,7 @@ export function withAuthFinder(
           )
         }
 
-        if (await hash.verify(passwordHash, password)) {
+        if (await hash().verify(passwordHash, password)) {
           return user
         }
 

--- a/tests/auth/mixins/with_auth_finder.spec.ts
+++ b/tests/auth/mixins/with_auth_finder.spec.ts
@@ -24,7 +24,7 @@ test.group('withAuthFinder | findForAuth', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -66,7 +66,7 @@ test.group('withAuthFinder | findForAuth', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -104,7 +104,7 @@ test.group('withAuthFinder | verify', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -141,7 +141,7 @@ test.group('withAuthFinder | verify', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -173,7 +173,7 @@ test.group('withAuthFinder | verify', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -211,7 +211,7 @@ test.group('withAuthFinder | verify', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -249,7 +249,7 @@ test.group('withAuthFinder | verify', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })
@@ -300,7 +300,7 @@ test.group('withAuthFinder | verify', () => {
 
     class User extends compose(
       BaseModel,
-      withAuthFinder(hash, {
+      withAuthFinder(() => hash, {
         uids: ['email', 'username'],
         passwordColumnName: 'password',
       })


### PR DESCRIPTION
Hey there! 👋🏻 

This PR changes the argument of `withAuthFinder`.

Before, we were receiving directly the hash module.

```ts
const AuthFinder = withAuthFinder(hash.use('scrypt'), {
  uids: ['email'],
  passwordColumnName: 'password',
})
```

This was causing some issues if you used the mixin before the app boot (i.e, in a command).

Moving to a function-based approach makes it work since we are delaying the access to `hash`.

```ts
const AuthFinder = withAuthFinder(() => hash.use('scrypt'), {
  uids: ['email'],
  passwordColumnName: 'password',
})
```

> [!NOTE] 
> Preset and documentation must be updated to reflect the change.