### PR TITLE
fix(mixins): remove withAuthFinder from root export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,5 +13,22 @@ export * as symbols from './src/symbols.js'
 export { AuthManager } from './src/auth_manager.js'
 export { defineConfig } from './src/define_config.js'
 export { Authenticator } from './src/authenticator.js'
-export { withAuthFinder } from './src/mixins/with_auth_finder.js'
 export { AuthenticatorClient } from './src/authenticator_client.js'
+
+function isModuleInstalled(moduleName: string) {
+  try {
+    import.meta.resolve(moduleName)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+// @deprecate Import `withAuthFinder` from `@adonisjs/auth/mixins` instead
+let withAuthFinder
+
+if (isModuleInstalled('@adonisjs/lucid')) {
+  withAuthFinder = await import('./src/mixins/with_auth_finder.js')
+}
+
+export { withAuthFinder }

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,9 @@ function isModuleInstalled(moduleName: string) {
   }
 }
 
-// @deprecate Import `withAuthFinder` from `@adonisjs/auth/mixins` instead
+/**
+ * @deprecated Import `withAuthFinder` from `@adonisjs/auth/mixins` instead
+ */
 let withAuthFinder: typeof withAuthFinderType
 
 if (isModuleInstalled('@adonisjs/lucid')) {

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ export { AuthManager } from './src/auth_manager.js'
 export { defineConfig } from './src/define_config.js'
 export { Authenticator } from './src/authenticator.js'
 export { AuthenticatorClient } from './src/authenticator_client.js'
+import type { withAuthFinder as withAuthFinderType } from './src/mixins/with_auth_finder.js'
 
 function isModuleInstalled(moduleName: string) {
   try {
@@ -25,10 +26,11 @@ function isModuleInstalled(moduleName: string) {
 }
 
 // @deprecate Import `withAuthFinder` from `@adonisjs/auth/mixins` instead
-let withAuthFinder
+let withAuthFinder: typeof withAuthFinderType
 
 if (isModuleInstalled('@adonisjs/lucid')) {
-  withAuthFinder = await import('./src/mixins/with_auth_finder.js')
+  const { withAuthFinder: withAuthFinderFn } = await import('./src/mixins/with_auth_finder.js')
+  withAuthFinder = withAuthFinderFn
 }
 
 export { withAuthFinder }

--- a/mixins.ts
+++ b/mixins.ts
@@ -1,0 +1,10 @@
+/*
+ * @adonisjs/auth
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export { withAuthFinder } from './src/mixins/with_auth_finder.js'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "exports": {
     ".": "./build/index.js",
+    "./mixins": "./build/mixins.js",
     "./types": "./build/src/types.js",
     "./auth_provider": "./build/providers/auth_provider.js",
     "./plugins/api_client": "./build/src/plugins/japa/api_client.js",

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
   "tsup": {
     "entry": [
       "./index.ts",
+      "./mixins.ts",
       "./src/types.ts",
       "./providers/auth_provider.ts",
       "./src/plugins/japa/api_client.ts",

--- a/tests/basic_auth/define_config.spec.ts
+++ b/tests/basic_auth/define_config.spec.ts
@@ -15,7 +15,7 @@ import { AppFactory } from '@adonisjs/core/factories/app'
 import type { ApplicationService } from '@adonisjs/core/types'
 import { HttpContextFactory } from '@adonisjs/core/factories/http'
 
-import { withAuthFinder } from '../../index.js'
+import { withAuthFinder } from '../../src/mixins/with_auth_finder.js'
 import { createEmitter, getHasher } from '../helpers.js'
 import {
   basicAuthGuard,

--- a/tests/basic_auth/user_providers/lucid.spec.ts
+++ b/tests/basic_auth/user_providers/lucid.spec.ts
@@ -11,7 +11,7 @@ import { test } from '@japa/runner'
 import { compose } from '@adonisjs/core/helpers'
 import { BaseModel, column } from '@adonisjs/lucid/orm'
 
-import { withAuthFinder } from '../../../index.js'
+import { withAuthFinder } from '../../../src/mixins/with_auth_finder.js'
 import { createDatabase, createTables, getHasher } from '../../helpers.js'
 import { BasicAuthGuardUser } from '../../../modules/basic_auth_guard/types.js'
 import { BasicAuthLucidUserProvider } from '../../../modules/basic_auth_guard/user_providers/lucid.js'


### PR DESCRIPTION
Hey there! 👋🏻 

This PR fixes the [hard dependency](https://github.com/adonisjs/auth/issues/236) we have on `@adonisjs/lucid`.

For the moment, I have written the helper `isModuleInstalled` in the root file, but we probably want it in a `@poppinss` package.