### PR TITLE
chore: add Basic auth guard

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -33,6 +33,10 @@ export async function configure(command: Configure) {
           name: 'access_tokens',
           message: 'Opaque access tokens',
         },
+        {
+          name: 'basic_auth',
+          message: 'Basic Auth',
+        },
       ],
       {
         validate(value) {
@@ -46,16 +50,16 @@ export async function configure(command: Configure) {
    * Ensure selected or guard defined via the CLI flag is
    * valid
    */
-  if (!['session', 'access_tokens'].includes(guard!)) {
+  if (!['session', 'access_tokens', 'basic_auth'].includes(guard!)) {
     command.logger.error(
-      `The selected guard "${guard}" is invalid. Select one from: session, access_tokens`
+      `The selected guard "${guard}" is invalid. Select one from: session, access_tokens, basic_auth`
     )
     command.exitCode = 1
     return
   }
 
   await presetAuth(codemods, command.app, {
-    guard: guard as 'session' | 'access_tokens',
+    guard: guard as 'session' | 'access_tokens' | 'basic_auth',
     userProvider: 'lucid',
   })
 }


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue. Reported in Discord and [Romain pointed me in the right place](https://discord.com/channels/423256550564691970/423263740402860036/1224468812645138493) for a PR.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The docs described Basic Auth as one of the options, but the CLI wouldn't accept it.

```sh
node ace add @adonisjs/auth --guard=basic_auth
```

```sh
The selected guard "basic_auth" is invalid. Select one from: session, access_tokens
```

This PR just adds the missing guard to the config list and adds the type in the missing places. 

Since many tests are already failing, I couldn't verify that this doesn't break anything.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
