### PR TITLE
Allow signing in users directly through the auth token guard

### DIFF
--- a/factories/access_tokens/main.ts
+++ b/factories/access_tokens/main.ts
@@ -132,6 +132,21 @@ export class AccessTokensFakeUserProvider
     return this.createUserForGuard(user)
   }
 
+  async invalidateToken(tokenValue: Secret<string>) {
+    const decodedToken = AccessToken.decode('oat_', tokenValue.release())
+    if (!decodedToken) {
+      return false
+    }
+
+    const index = this.#tokens.findIndex(({ id }) => id === decodedToken.identifier)
+
+    if (index === -1) {
+      return false
+    }
+    this.#tokens.splice(index, 1)
+    return true
+  }
+
   async verifyToken(tokenValue: Secret<string>): Promise<AccessToken | null> {
     const decodedToken = AccessToken.decode('oat_', tokenValue.release())
     if (!decodedToken) {

--- a/modules/access_tokens_guard/guard.ts
+++ b/modules/access_tokens_guard/guard.ts
@@ -217,6 +217,20 @@ export class AccessTokensGuard<UserProvider extends AccessTokensUserProviderCont
   }
 
   /**
+   * Create a token for a user (sign in)
+   */
+  async createToken(
+    user: UserProvider[typeof PROVIDER_REAL_USER],
+    abilities?: string[],
+    options?: {
+      expiresIn?: string | number
+      name?: string
+    }
+  ) {
+    return await this.#userProvider.createToken(user, abilities, options)
+  }
+
+  /**
    * Returns the Authorization header clients can use to authenticate
    * the request.
    */

--- a/modules/access_tokens_guard/guard.ts
+++ b/modules/access_tokens_guard/guard.ts
@@ -231,6 +231,14 @@ export class AccessTokensGuard<UserProvider extends AccessTokensUserProviderCont
   }
 
   /**
+   * Invalidates the currently authenticated token (sign out)
+   */
+  async invalidateToken() {
+    const bearerToken = new Secret(this.#getBearerToken())
+    return await this.#userProvider.invalidateToken(bearerToken)
+  }
+
+  /**
    * Returns the Authorization header clients can use to authenticate
    * the request.
    */

--- a/modules/access_tokens_guard/token_providers/db.ts
+++ b/modules/access_tokens_guard/token_providers/db.ts
@@ -330,4 +330,24 @@ export class DbAccessTokensProvider<TokenableModel extends LucidModel>
 
     return accessToken
   }
+
+  /**
+   * Invalidates a token identified by its publicly shared token
+   */
+  async invalidate(tokenValue: Secret<string>) {
+    const decodedToken = AccessToken.decode(this.prefix, tokenValue.release())
+    if (!decodedToken) {
+      return false
+    }
+
+    const db = await this.getDb()
+    const deleteCount = await db
+      .query<AccessTokenDbColumns>()
+      .from(this.table)
+      .where({ id: decodedToken.identifier, type: this.type })
+      .del()
+      .exec()
+
+    return Boolean(deleteCount)
+  }
 }

--- a/modules/access_tokens_guard/types.ts
+++ b/modules/access_tokens_guard/types.ts
@@ -149,6 +149,11 @@ export interface AccessTokensProviderContract<Tokenable extends LucidModel> {
    * access token for it.
    */
   verify(tokenValue: Secret<string>): Promise<AccessToken | null>
+
+  /**
+   * Invalidates a token identified by its publicly shared token
+   */
+  invalidate(tokenValue: Secret<string>): Promise<boolean>
 }
 
 /**
@@ -209,6 +214,11 @@ export interface AccessTokensUserProviderContract<RealUser> {
       expiresIn?: string | number
     }
   ): Promise<AccessToken>
+
+  /**
+   * Invalidates a token identified by its publicly shared token.
+   */
+  invalidateToken(tokenValue: Secret<string>): Promise<boolean>
 
   /**
    * Find a user by the user id.

--- a/modules/access_tokens_guard/user_providers/lucid.ts
+++ b/modules/access_tokens_guard/user_providers/lucid.ts
@@ -120,6 +120,14 @@ export class AccessTokensLucidUserProvider<
   }
 
   /**
+   * Invalidates a token identified by its publicly shared token
+   */
+  async invalidateToken(tokenValue: Secret<string>) {
+    const tokensProvider = await this.getTokensProvider()
+    return tokensProvider.invalidate(tokenValue)
+  }
+
+  /**
    * Finds a user by the user id
    */
   async findById(

--- a/tests/access_tokens/guard/authenticate.spec.ts
+++ b/tests/access_tokens/guard/authenticate.spec.ts
@@ -366,3 +366,24 @@ test.group('Access tokens guard | authenticateAsClient', () => {
     assert.match(response.headers!.authorization, /Bearer oat_[a-zA-Z0-9]+\.[a-zA-Z0-9]+/)
   })
 })
+
+test.group('Access tokens guard | createToken', () => {
+  test('create bearer token for the given user', async ({ assert }) => {
+    const ctx = new HttpContextFactory().create()
+    const emitter = createEmitter<AccessTokensGuardEvents<AccessTokensFakeUser>>()
+    const userProvider = new AccessTokensFakeUserProvider()
+
+    const guard = new AccessTokensGuard('api', ctx, emitter, userProvider)
+    const user = await userProvider.findById(1)
+    const token = await guard.createToken(user!.getOriginal(), ['list.users'], {
+      expiresIn: 3600,
+      name: 'sign_in',
+    })
+    assert.instanceOf(token, AccessToken)
+    assert.equal(token.tokenableId, user?.getId())
+    assert.deepEqual(token.abilities, ['list.users'])
+    assert.equal(token.name, 'sign_in')
+    assert.closeTo(token.expiresAt!.getTime(), new Date().getTime() + 3600 * 1000, 100)
+    assert.match(token.value!.release(), /oat_[a-zA-Z0-9]+\.[a-zA-Z0-9]+/)
+  })
+})

--- a/tests/access_tokens/guard/authenticate.spec.ts
+++ b/tests/access_tokens/guard/authenticate.spec.ts
@@ -387,3 +387,47 @@ test.group('Access tokens guard | createToken', () => {
     assert.match(token.value!.release(), /oat_[a-zA-Z0-9]+\.[a-zA-Z0-9]+/)
   })
 })
+
+test.group('Access tokens guard | invalidateToken', () => {
+  test('return true when token was successfully invalidated', async ({ assert }) => {
+    const ctx = new HttpContextFactory().create()
+    const emitter = createEmitter<AccessTokensGuardEvents<AccessTokensFakeUser>>()
+    const userProvider = new AccessTokensFakeUserProvider()
+
+    const guard = new AccessTokensGuard('api', ctx, emitter, userProvider)
+    const user = await userProvider.findById(1)
+    const token = await guard.createToken(user!.getOriginal())
+
+    ctx.request.request.headers.authorization = `Bearer ${token.value!.release()}`
+
+    assert.isTrue(await guard.invalidateToken())
+  })
+
+  test('return false when token was already invalidated', async ({ assert }) => {
+    const ctx = new HttpContextFactory().create()
+    const emitter = createEmitter<AccessTokensGuardEvents<AccessTokensFakeUser>>()
+    const userProvider = new AccessTokensFakeUserProvider()
+
+    const guard = new AccessTokensGuard('api', ctx, emitter, userProvider)
+    const user = await userProvider.findById(1)
+    const token = await guard.createToken(user!.getOriginal())
+
+    ctx.request.request.headers.authorization = `Bearer ${token.value!.release()}`
+
+    await guard.invalidateToken()
+
+    assert.isFalse(await guard.invalidateToken())
+  })
+
+  test('return false when invalid token', async ({ assert }) => {
+    const ctx = new HttpContextFactory().create()
+    const emitter = createEmitter<AccessTokensGuardEvents<AccessTokensFakeUser>>()
+    const userProvider = new AccessTokensFakeUserProvider()
+
+    const guard = new AccessTokensGuard('api', ctx, emitter, userProvider)
+
+    ctx.request.request.headers.authorization = `Bearer 1234567890`
+
+    assert.isFalse(await guard.invalidateToken())
+  })
+})

--- a/tests/access_tokens/token_providers/db.spec.ts
+++ b/tests/access_tokens/token_providers/db.spec.ts
@@ -721,3 +721,100 @@ test.group('Access tokens provider | DB | all', () => {
     assert.isFalse(tokens[0].isExpired())
   })
 })
+
+test.group('Access tokens provider | DB | invalidate', () => {
+  test('delete token identified by publicly shared token', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const user = await User.create({
+      email: 'virk@adonisjs.com',
+      username: 'virk',
+      password: 'secret',
+    })
+
+    const token = await User.authTokens.create(user, ['*'], { name: 'List projects' })
+
+    assert.isNotEmpty(await User.authTokens.all(user))
+
+    const invalidateResult = await User.authTokens.invalidate(token.value!)
+
+    assert.isTrue(invalidateResult)
+    assert.isEmpty(await User.authTokens.all(user))
+  })
+
+  test('return false if invalid token', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const invalidateResult = await User.authTokens.invalidate(new Secret('invalid-token'))
+
+    assert.isFalse(invalidateResult)
+  })
+
+  test('return false if token was already invalidated', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const user = await User.create({
+      email: 'virk@adonisjs.com',
+      username: 'virk',
+      password: 'secret',
+    })
+
+    const token = await User.authTokens.create(user, ['*'], { name: 'List projects' })
+    await User.authTokens.invalidate(token.value!)
+
+    const invalidateResult = await User.authTokens.invalidate(token.value!)
+
+    assert.isFalse(invalidateResult)
+  })
+})

--- a/tests/access_tokens/user_providers/lucid.spec.ts
+++ b/tests/access_tokens/user_providers/lucid.spec.ts
@@ -149,6 +149,123 @@ test.group('Access tokens user provider | Lucid | createToken', () => {
   })
 })
 
+test.group('Access tokens user provider | Lucid | invalidateToken', () => {
+  test('return true if token was invalidated', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const userProvider = new AccessTokensLucidUserProvider({
+      tokens: 'authTokens',
+      async model() {
+        return {
+          default: User,
+        }
+      },
+    })
+
+    const user = await User.create({
+      email: 'virk@adonisjs.com',
+      username: 'virk',
+      password: 'secret',
+    })
+
+    const token = await User.authTokens.create(user)
+    const result = await userProvider.invalidateToken(token.value!)
+    assert.isTrue(result)
+  })
+
+  test('return false if not a real token', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const userProvider = new AccessTokensLucidUserProvider({
+      tokens: 'authTokens',
+      async model() {
+        return {
+          default: User,
+        }
+      },
+    })
+
+    const result = await userProvider.invalidateToken(new Secret('not-a-real-token'))
+    assert.isFalse(result)
+  })
+
+  test('return false if token is not longer valid', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const userProvider = new AccessTokensLucidUserProvider({
+      tokens: 'authTokens',
+      async model() {
+        return {
+          default: User,
+        }
+      },
+    })
+
+    const user = await User.create({
+      email: 'virk@adonisjs.com',
+      username: 'virk',
+      password: 'secret',
+    })
+
+    const token = await User.authTokens.create(user)
+    await userProvider.invalidateToken(token.value!)
+
+    const result = await userProvider.invalidateToken(token.value!)
+    assert.isFalse(result)
+  })
+})
+
 test.group('Access tokens user provider | Lucid | findById', () => {
   test('find user by id', async ({ assert }) => {
     const db = await createDatabase()


### PR DESCRIPTION
### 🔗 Linked issue

I jumped right to the "making a PR"-step, I hope that it is okay? Otherwise I'll create an issue.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow signing in users directly through the auth token guard, like it is possible to do with the session guard.

This makes it a lot simpler to use a non-lucid user provider for the access token guard, as otherwise controllers have to use "authenticateAsClient" - which is meant for test purposes, or the token creation logic would have to be extracted to a separate service/provider, which would then have to be made available to the controllers.

We hit this issues as we were building a kysely token user provider for our app project. To our surprise we could not sign in a user through the auth guard, like we are used to for session guard.

I'd like to also add a `logout`-method to the guard, but adding that means extending the `AccessTokensUserProviderContract` (with an `invalidateToken`-method), which seems like a slightly bigger change. So I started with the part that creates the token.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
