### PR TITLE
fix: case insensitive bearer token

### DIFF
--- a/modules/access_tokens_guard/guard.ts
+++ b/modules/access_tokens_guard/guard.ts
@@ -126,8 +126,8 @@ export class AccessTokensGuard<UserProvider extends AccessTokensUserProviderCont
    */
   #getBearerToken(): string {
     const bearerToken = this.#ctx.request.header('authorization', '')!
-    const [, token] = bearerToken.split('Bearer ')
-    if (!token) {
+    const [type, token] = bearerToken.split(' ')
+    if (!type || type.toLowerCase() !== 'bearer' || !token) {
       throw this.#authenticationFailed()
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

[#254](https://github.com/adonisjs/auth/issues/254)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes the Bearer word in the Authorization header value case-insensitive as it should be according to the standard.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
