### PR TITLE
feat: allow to pass custom guard to check method

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -229,4 +229,24 @@ export class Authenticator<KnownGuards extends Record<string, GuardFactory>> {
       redirectTo: options?.loginRoute,
     })
   }
+
+  /**
+   * Silently attempt to authenticate the request using all of the mentioned guards
+   * or the default guard. Calling this method multiple times triggers multiple
+   * authentication with the guard.
+   */
+  async checkUsing(guards: (keyof KnownGuards)[] = [this.defaultGuard]) {
+    for (const name of guards) {
+      this.#authenticationAttemptedViaGuard = name
+      const isAuthenticated = await this.use(name).check()
+
+      if (isAuthenticated) {
+        this.#authenticatedViaGuard = name
+
+        return true
+      }
+    }
+
+    return false
+  }
 }

--- a/tests/auth/authenticator.spec.ts
+++ b/tests/auth/authenticator.spec.ts
@@ -171,4 +171,27 @@ test.group('Authenticator', () => {
     assert.isFalse(authenticator.isAuthenticated)
     assert.isTrue(authenticator.authenticationAttempted)
   })
+
+  test('check authentication using multiple guards', async ({ assert }) => {
+    const ctx = new HttpContextFactory().create()
+    const authenticator = new Authenticator(ctx, {
+      default: 'web1',
+      guards: {
+        web1: () => new FakeGuard(),
+        web2: () => new FakeGuard(),
+      },
+    })
+
+    authenticator.use('web1').authenticate = async function () {
+      this.authenticationAttempted = true
+      return this.getUserOrFail()
+    }
+
+    const isAuthenticated = await authenticator.checkUsing(['web1', 'web2'])
+
+    assert.isTrue(isAuthenticated)
+    assert.isTrue(authenticator.isAuthenticated)
+    assert.isTrue(authenticator.authenticationAttempted)
+    assert.equal(authenticator.authenticatedViaGuard, 'web2')
+  })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This update allows to pass custom or multiple guards to `auth.check()` method. For example we have multiple guards and we want to check for authentication on all guards without actually requiring to be authenticated.
