### PR TITLE
fix: emit event session logout before update local data

### DIFF
--- a/modules/session_guard/guard.ts
+++ b/modules/session_guard/guard.ts
@@ -468,14 +468,6 @@ export class SessionGuard<
     }
 
     /**
-     * Update local state
-     */
-    this.user = undefined
-    this.viaRemember = false
-    this.isAuthenticated = false
-    this.isLoggedOut = true
-
-    /**
      * Notify the user has been logged out
      */
     this.#emitter.emit('session_auth:logged_out', {
@@ -484,6 +476,14 @@ export class SessionGuard<
       user: this.user || null,
       sessionId: session.sessionId,
     })
+
+    /**
+     * Update local state
+     */
+    this.user = undefined
+    this.viaRemember = false
+    this.isAuthenticated = false
+    this.isLoggedOut = true
   }
 
   /**

--- a/tests/session/guard/logout.spec.ts
+++ b/tests/session/guard/logout.spec.ts
@@ -24,6 +24,7 @@ test.group('Session guard | logout', () => {
   test('delete user session and remember me cookie', async ({ assert }) => {
     const ctx = new HttpContextFactory().create()
     const emitter = createEmitter<SessionGuardEvents<SessionFakeUser>>()
+    const events = emitter.fake()
     const userProvider = new SessionFakeUserProvider()
 
     const guard = new SessionGuard(
@@ -54,11 +55,15 @@ test.group('Session guard | logout', () => {
     const responseCookies = parseCookies(ctx.response.getHeader('set-cookie') as string)
     assert.deepEqual(responseCookies.remember_web.expires, new Date(0))
     assert.deepEqual(responseCookies.remember_web.maxAge, -1)
+
+    events.assertEmittedCount('session_auth:logged_out', 1)
+    assert.equal(events.find('session_auth:logged_out')!.data.user, user!.getOriginal())
   })
 
   test('delete remember me token using user provider', async ({ assert }) => {
     const ctx = new HttpContextFactory().create()
     const emitter = createEmitter<SessionGuardEvents<SessionFakeUser>>()
+    const events = emitter.fake()
     const userProvider = new SessionFakeUserWithTokensProvider()
 
     const guard = new SessionGuard(
@@ -99,6 +104,9 @@ test.group('Session guard | logout', () => {
     assert.deepEqual(responseCookies.remember_web.maxAge, -1)
 
     assert.lengthOf(userProvider.tokens, 0)
+
+    events.assertEmittedCount('session_auth:logged_out', 1)
+    assert.equal(events.find('session_auth:logged_out')!.data.user, user!.getOriginal())
   })
 
   test('do not delete token with storage when no user was authenticated in first place', async ({
@@ -106,6 +114,7 @@ test.group('Session guard | logout', () => {
   }) => {
     const ctx = new HttpContextFactory().create()
     const emitter = createEmitter<SessionGuardEvents<SessionFakeUser>>()
+    const events = emitter.fake()
     const userProvider = new SessionFakeUserWithTokensProvider()
 
     const guard = new SessionGuard(
@@ -145,5 +154,8 @@ test.group('Session guard | logout', () => {
     assert.deepEqual(responseCookies.remember_web.maxAge, -1)
 
     assert.lengthOf(userProvider.tokens, 1)
+
+    events.assertEmittedCount('session_auth:logged_out', 1)
+    assert.isNull(events.find('session_auth:logged_out')!.data.user)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/adonisjs/auth/issues/258

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request fixes the issue where the user field in the payload of session_auth:logged_out event was always null.

The problem occurred because the event was emitted after update the local data in session guard state, which made the user field is undefined.

Resolves https://github.com/adonisjs/auth/issues/258


<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
