### PR TITLE
feat: add deleteAll method on access token provider

### DIFF
--- a/modules/access_tokens_guard/token_providers/db.ts
+++ b/modules/access_tokens_guard/token_providers/db.ts
@@ -321,6 +321,29 @@ export class DbAccessTokensProvider<
   }
 
   /**
+   * Delete all tokens for a given user
+   *
+   * @param user - The user instance to delete tokens for
+   *
+   * @example
+   * const deletedCount = await provider.delete(user)
+   * console.log('Deleted tokens:', deletedCount)
+   */
+  async deleteAll(user: InstanceType<TokenableModel>): Promise<number> {
+    this.#ensureIsPersisted(user)
+
+    const queryClient = await this.getDb()
+    const affectedRows = await queryClient
+      .query<number>()
+      .from(this.table)
+      .where({ tokenable_id: user.$primaryKeyValue, type: this.type })
+      .del()
+      .exec()
+
+    return affectedRows as unknown as number
+  }
+
+  /**
    * Returns all the tokens for a given user
    *
    * @param user - The user instance to get tokens for

--- a/modules/access_tokens_guard/token_providers/db.ts
+++ b/modules/access_tokens_guard/token_providers/db.ts
@@ -326,7 +326,7 @@ export class DbAccessTokensProvider<
    * @param user - The user instance to delete tokens for
    *
    * @example
-   * const deletedCount = await provider.delete(user)
+   * const deletedCount = await provider.deleteAll(user)
    * console.log('Deleted tokens:', deletedCount)
    */
   async deleteAll(user: InstanceType<TokenableModel>): Promise<number> {

--- a/tests/access_tokens/token_providers/db.spec.ts
+++ b/tests/access_tokens/token_providers/db.spec.ts
@@ -722,6 +722,43 @@ test.group('Access tokens provider | DB | all', () => {
   })
 })
 
+test.group('Access tokens provider | DB | deleteAll', () => {
+  test('delete all tokens', async ({ assert }) => {
+    const db = await createDatabase()
+    await createTables(db)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare password: string
+
+      static authTokens = DbAccessTokensProvider.forModel(User)
+    }
+
+    const user = await User.create({
+      email: 'virk@adonisjs.com',
+      username: 'virk',
+      password: 'secret',
+    })
+
+    await User.authTokens.create(user, ['*'], { expiresIn: '20 mins', name: 'List projects' })
+    await User.authTokens.create(user)
+    timeTravel(21 * 60)
+    const numberOfDeletedTokens = await User.authTokens.deleteAll(user)
+
+    assert.equal(numberOfDeletedTokens, 2)
+    assert.isEmpty(await User.authTokens.all(user))
+  })
+})
+
 test.group('Access tokens provider | DB | invalidate', () => {
   test('delete token identified by publicly shared token', async ({ assert }) => {
     const db = await createDatabase()


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This adds ability to delete all tokens for a given user. Useful when they change their password or flagged.

Currently, one could get all tokens and then delete it in a loop, but this does that in one query. Good if it's possible a user has many tokens.

[Documentation Update](https://github.com/adonisjs/v6-docs/pull/253)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
