### PR TITLE
Fix last_used_at update in token provider

### DIFF
--- a/modules/access_tokens_guard/token_providers/db.ts
+++ b/modules/access_tokens_guard/token_providers/db.ts
@@ -432,7 +432,7 @@ export class DbAccessTokensProvider<
     /**
      * Convert to access token instance
      */
-    const accessToken = this.dbRowToAccessToken(dbRow)
+    const accessToken = this.dbRowToAccessToken({ ...dbRow, last_used_at })
 
     /**
      * Ensure the token secret matches the token hash

--- a/modules/access_tokens_guard/token_providers/db.ts
+++ b/modules/access_tokens_guard/token_providers/db.ts
@@ -423,11 +423,11 @@ export class DbAccessTokensProvider<
     /**
      * Update last time the token is used
      */
-    dbRow.last_used_at = new Date()
+    const last_used_at = new Date()
     await db
       .from(this.table)
       .where({ id: dbRow.id, type: dbRow.type })
-      .update({ last_used_at: dbRow.last_used_at })
+      .update({ last_used_at: last_used_at })
 
     /**
      * Convert to access token instance


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Inside the verify method of the token provider, create a variable to hold the new last_updated_date instead of mutating the dbRow object.

this change fixes usage with libsql, where I would get an error (shown below), it seems like the orm/knex returns an immutable object with the libsql driver

<details>
<summary>Cannot assign to read only property 'last_used_at' of object</summary>

```
[20:30:58.611] ERROR (1597693): Cannot assign to read only property 'last_used_at' of object '#<Object>'
    request_id: "cc3ae566-7ce9-4ea7-8c2c-2bf03c716ac7"
    x-request-id: "cc3ae566-7ce9-4ea7-8c2c-2bf03c716ac7"
    err: {
      "type": "TypeError",
      "message": "Cannot assign to read only property 'last_used_at' of object '#<Object>'",
      "stack":
          TypeError: Cannot assign to read only property 'last_used_at' of object '#<Object>'
              at DbAccessTokensProvider.verify (file://path/to/project/node_modules/@adonisjs/auth/build/modules/access_tokens_guard/main.js:1199:22)
              at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
              at async AccessTokensGuard.authenticate (file://path/to/project/node_modules/@adonisjs/auth/build/modules/access_tokens_guard/main.js:795:17)
              at async AccessTokensGuard.check (file://path/to/project/node_modules/@adonisjs/auth/build/modules/access_tokens_guard/main.js:877:4)
              at async Authenticator.check (file://path/to/project/node_modules/@adonisjs/auth/build/auth_manager-Cp_ofh4p.js:190:27)
              at async SilentAuthMiddleware.handle (/home/zorvi/Projects/lepse/apps/clotho/app/middleware/silent_auth_middleware.ts:12:5)
              at async ShieldMiddleware.handle (file://path/to/project/node_modules/@adonisjs/shield/build/src/shield_middleware.js:17:3)
              at async SessionMiddleware.handle (file://path/to/project/node_modules/@adonisjs/session/build/src/session_middleware.js:110:20)
              at async file://path/to/project/node_modules/@adonisjs/static/build/chunk-DUKWVYYP.js:85:11
      "status": 500
    }
```
</details>

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

neither was possible nor directly related, I'm willing to if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access token usage tracking during verification.
  * Ensured the recorded last-used timestamp is applied consistently to verified tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->